### PR TITLE
fix "y" the default to quit

### DIFF
--- a/cl-repl.asd
+++ b/cl-repl.asd
@@ -4,7 +4,7 @@
 (in-package :cl-repl)
 
 (defsystem cl-repl
-  :version "0.3.2"
+  :version "0.3.3"
   :author "TANI Kojiro"
   :license "MIT"
   :depends-on (#:alexandria

--- a/src/cl-repl.lisp
+++ b/src/cl-repl.lisp
@@ -4,7 +4,7 @@
   (:export +version+ *splash* repl))
 (in-package #:cl-repl)
 
-(defconstant +version+ :0.3.2)
+(defconstant +version+ :0.3.3)
 
 (defun bold (string)
   (format nil "~C[~Am~A~C[0m" (code-char #o33) "1" string (code-char #o33)))
@@ -27,11 +27,12 @@
 (defun exit-with-prompt ()
   (finish-output)
   (alexandria:switch
-   ((rl:readline :prompt "Do you really want to exit ([y]/n)? ") :test #'equal)
-   ("y" (error 'exit-error))
-   (nil (progn (format t "~%") (error 'exit-error)))
-   ("n" (setf *last-input* "nil"))
-   (t (exit-with-prompt))))
+      ((rl:readline :prompt "Do you really want to exit ([y]/n)? ") :test #'equal)
+    ("y" (error 'exit-error))
+    ("" (error 'exit-error))
+    (nil (progn (format t "~%") (error 'exit-error)))
+    ("n" (setf *last-input* "nil"))
+    (t (exit-with-prompt))))
 
 (defun prompt ()
   (format nil "~a> " (car (package-nicknames *package*))))


### PR DESCRIPTION
Hello,

First of all: CONGRATS, this is really awesome ! There is room for more features (highlight matching parens, proper restarts…), but cl-repl already offers a lot and it fills a need. I really like it :)

In this PR:

- "y" is the default option when quitting (it didn't work)
- I didn't know how to test with roswell, so I added the ability to build an executable.

Thanks, see you !