### PR TITLE
do not add debugger choices to history

### DIFF
--- a/src/cl-repl.lisp
+++ b/src/cl-repl.lisp
@@ -44,8 +44,8 @@
               repeat (1- (length prompt))
               collect "."))))
 
-(defun read-input (&key (prompt (prompt)))
-  (let ((input (rl:readline :prompt (bold (cl-ansi-text:green prompt)) :add-history t)))
+(defun read-input (&key (prompt (prompt)) (add-history t))
+  (let ((input (rl:readline :prompt (bold (cl-ansi-text:green prompt)) :add-history add-history)))
     (if (not input)
         (progn
           (format t "~%")
@@ -83,7 +83,7 @@
   (let ((last-input *last-input*))
     (loop
        (handler-case
-           (let ((input (read-input :prompt "DEBUG> ")))
+           (let ((input (read-input :prompt "DEBUG> " :add-history nil)))
              (handler-case
                  (alexandria:switch (input)
                                     (0 (progn


### PR DESCRIPTION

a simple addition to not add the debugger's "1" and "2"s to the history.