### PR TITLE
build an executable with asdf:make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+LISP?=sbcl
+
+build:
+	$(LISP) --load "cl-repl.asd" \
+	     --eval '(ql:quickload :cl-repl)' \
+	     --eval '(asdf:make :cl-repl)'

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ CL-REPL is distributed under [MIT license](LICENSE).
 Don't hesitate to open issues or to send pull requests!  
 The authors are unfamiliar to Common Lisp, as well as English...
 
+To test locally, you can build an executable with `make build`.
+
 # Author
 
 [TANI Kojiro](https://github.com/koji-kojiro) (kojiro0531@gmail.com)

--- a/cl-repl.asd
+++ b/cl-repl.asd
@@ -19,5 +19,8 @@
 	       #:trivial-documentation
 	       #:split-sequence)
   :components ((:module "src" :components ((:file "cl-repl"))))
+  :build-operation "program-op"
+  :build-pathname "cl-repl"
+  :entry-point "cl-repl:repl"
   :description "A full-featured repl implementation."
   :long-description "A full-featured repl implementation.")

--- a/src/cl-repl.lisp
+++ b/src/cl-repl.lisp
@@ -168,7 +168,6 @@
         (cons (common-prefix els) els)
         els)))
 
-(rl:register-function :complete #'completer)
 
 (defun introspectionp (input)
   (alexandria:starts-with-subseq "?" input))
@@ -297,6 +296,9 @@
 
 (defun repl (&key (load nil))
   (in-package :cl-user)
+
+  (rl:register-function :complete #'completer)
+
   (macrolet ((print-with-handler (&rest body)
 	       `(handler-case
 		    (write-output ,@body)


### PR DESCRIPTION
Now the completion works (just had to put 

      (rl:register-function :complete #'completer)

inside the repl function).

Building an executable will allow to distribute cl-repl differently, and more easily, without the help of roswell for those who do not want. I find this possibility nice. 

(I let Gitlab CI build an executable at each new tag for me, documented [here](https://lispcookbook.github.io/cl-cookbook/testing.html#gitlab-ci), should be similar for github)