### PR TITLE
remove package definition for the inconsistent package dep

### DIFF
--- a/cl-repl.asd
+++ b/cl-repl.asd
@@ -1,8 +1,3 @@
-(in-package :cl-user)
-(defpackage cl-repl
-  (:use #:cl #:asdf))
-(in-package :cl-repl)
-
 (defsystem cl-repl
   :version "0.3.3"
   :author "TANI Kojiro"


### PR DESCRIPTION
**_define packages in asd file and source file with different deps_,**

sbcl's loading warning:
```common-lisp
; file: /home/clx/.quicklisp/local-projects/cl-repl/src/cl-repl.lisp
; in: DEFPACKAGE #:CL-REPL
;     (DEFPACKAGE #:CL-REPL
;       (:USE #:CL)
;       (:EXPORT +VERSION+ *SPLASH* REPL))
; --> EVAL-WHEN
; ==>
;   (SB-IMPL::%DEFPACKAGE "CL-REPL" 'NIL 'NIL 'NIL 'NIL '("CL") 'NIL 'NIL
;                         '("+VERSION+" "*SPLASH*" "REPL") '("CL-REPL") 'NIL ...)
;
; caught WARNING:
;   CL-REPL also uses the following packages:
;     (ASDF/INTERFACE)
;   See also:
;     The ANSI Standard, Macro DEFPACKAGE
;     The SBCL Manual, Variable *ON-PACKAGE-VARIANCE*
```