### PR TITLE
Support external pager (e.g. less) for output with long lines

### DIFF
--- a/cl-repl.asd
+++ b/cl-repl.asd
@@ -1,5 +1,5 @@
 (defsystem cl-repl
-  :version "0.5.0"
+  :version "0.5.1"
   :author "TANI Kojiro"
   :license "GPLv3"
   :depends-on (#:alexandria
@@ -15,6 +15,7 @@
                                            (:file "color-scheme")
                                            (:file "highlight")
                                            (:file "keymap")
+                                           (:file "pager")
                                            (:file "command")
                                            (:file "shell")
                                            (:file "completer")

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -1,6 +1,6 @@
 (in-package :cl-repl)
 
-(defconstant +version+ '0.5.0)
+(defconstant +version+ '0.5.1)
 
 (defvar *logo*
   "  ___  __          ____  ____  ____  __

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -7,6 +7,8 @@
            define-color-scheme
            color-scheme
            disable-syntax
+           *pager-command*
+           *pager-minimum-line-count*
            *default-prompt-function*
            *debugger-prompt-function*
            *output-indicator-function*

--- a/src/pager.lisp
+++ b/src/pager.lisp
@@ -1,0 +1,23 @@
+(in-package :cl-repl)
+
+(defparameter *pager-command* "less")
+(defparameter *pager-minimum-line-count* 10)
+
+(defun probe-pager-command ()
+  (handler-case
+      (progn
+        (uiop:run-program
+         (format nil "command -v ~a" *pager-command*))
+        t)
+    (error () nil)))
+
+(defun invoke-pager (text)
+  (if (and (probe-pager-command)
+           (> (/ (length (ppcre:all-matches "\\n" text)) 2)
+              *pager-minimum-line-count*))
+      (uiop:run-program
+       (format nil "echo ~s | ~a" text *pager-command*)
+       :ignore-error-status t
+       :input :interactive
+       :output :interactive)
+      (format t text)))


### PR DESCRIPTION
# Added features
- Show backtrace with external pager (default: less)

# Bug fixes
- debugger invoked on another debugger does not work properly. 9297fa8