### PR TITLE
v0.6.0

### DIFF
--- a/cl-repl.asd
+++ b/cl-repl.asd
@@ -21,6 +21,7 @@
                                            (:file "shell")
                                            (:file "completer")
                                            (:file "debugger")
+                                           (:file "inspector")
                                            (:file "input")
                                            (:file "repl")
                                            (:file "main"))))

--- a/cl-repl.asd
+++ b/cl-repl.asd
@@ -2,16 +2,14 @@
   :version "0.5.1"
   :author "TANI Kojiro"
   :license "GPLv3"
-  :depends-on (#:alexandria
-               #:uiop
+  :depends-on (#:uiop
                #:unix-opts
-               #:split-sequence
-               #:trivial-backtrace
                #:conium
                #:cl-ppcre
                #:cl-readline)
   :serial t
   :components ((:module "src" :components ((:file "package")
+                                           (:file "util")
                                            (:file "color")
                                            (:file "color-scheme")
                                            (:file "highlight")

--- a/cl-repl.asd
+++ b/cl-repl.asd
@@ -7,6 +7,7 @@
                #:unix-opts
                #:split-sequence
                #:trivial-backtrace
+               #:conium
                #:cl-ppcre
                #:cl-readline)
   :serial t

--- a/cl-repl.asd
+++ b/cl-repl.asd
@@ -1,5 +1,5 @@
 (defsystem cl-repl
-  :version "0.5.1"
+  :version "0.6.0"
   :author "TANI Kojiro"
   :license "GPLv3"
   :depends-on (#:uiop

--- a/cl-repl.asd
+++ b/cl-repl.asd
@@ -1,5 +1,5 @@
 (defsystem cl-repl
-  :version "0.5.0"
+  :version "0.5.1"
   :author "TANI Kojiro"
   :license "GPLv3"
   :depends-on (#:alexandria
@@ -15,6 +15,7 @@
                                            (:file "color-scheme")
                                            (:file "highlight")
                                            (:file "keymap")
+                                           (:file "pager")
                                            (:file "command")
                                            (:file "shell")
                                            (:file "completer")

--- a/src/color-scheme.lisp
+++ b/src/color-scheme.lisp
@@ -19,6 +19,7 @@
           :do (set-color spec color))))
 
 (define-color-scheme "default" ()
+  ("magic-syntax" 39)
   ("string-syntax" 184)
   ("variable-syntax" 118)
   ("constant-syntax" 118)
@@ -38,6 +39,7 @@
   ("logo" 9))
 
 (define-color-scheme "off" ()
+  ("magic-syntax" nil)
   ("string-syntax" nil)
   ("variable-syntax" nil)
   ("constant-syntax" nil)

--- a/src/color.lisp
+++ b/src/color.lisp
@@ -14,6 +14,7 @@
 (defparameter *section-color* 21)
 (defparameter *message-color* 248)
 
+(defparameter *magic-syntax-color* 39)
 (defparameter *string-syntax-color* 184)
 (defparameter *variable-syntax-color* 118)
 (defparameter *constant-syntax-color* 118)

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -33,7 +33,7 @@
   "Execute file in current enviroment."
   (declare (ignore args))
   (if (probe-file filename)
-      (let ((code (format nil "(progn ~a )" (alexandria:read-file-into-string filename))))
+      (let ((code (format nil "(progn ~a )" (read-file-into-string filename))))
         (if (line-continue-p code)
             (message-from-magic "Error: Unexpected EOF.")
             code))

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -79,6 +79,13 @@
         (message-from-magic "Error: Unexpected EOF.")
         code)))
 
+(define-magic step (&rest forms)
+  "Alias to (step <form>)."
+  (let ((code (format nil "(step ~{ ~a~})" forms)))
+    (if (line-continue-p code)
+        (message-from-magic "Error: Unexpected EOF.")
+        code)))
+
 #+quicklisp
 (define-magic load (&rest systems)
   "Alias to (ql:quickload '(<system>...) :silent t)."

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -3,13 +3,14 @@
 (defvar *magic-commands* nil)
 
 (defmacro define-magic (name args &body body)
-  `(progn
-     #+sbcl
-     (sb-ext:without-package-locks
-       (export (intern ,(format nil "%~a" name) :cl) :cl))
-     (push (list ,(format nil "%~(~a~)" name)
-                 #'(lambda ,args ,@body))
-           *magic-commands*)))
+  (let ((symname (format nil "%~(~a~)" name)))
+    `(progn
+       #+sbcl
+       (sb-ext:without-package-locks
+         (export (intern ,symname :cl) :cl)
+         (shadow (intern ,symname :cl) :cl))
+       (push (list ,symname #'(lambda ,args ,@body))
+             *magic-commands*))))
 
 (defmacro message-from-magic (message &rest args)
   `(progn

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -27,7 +27,7 @@
   (message-from-magic "Command not found.: ~a" magic))
 
 (defun input-magic-p (&optional input)
-  (alexandria:starts-with-subseq "%" input))
+  (string-starts-with input "%"))
 
 (define-magic run (filename &rest args)
   "Execute file in current enviroment."

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -159,6 +159,8 @@
   "Clear screen."
   (declare (ignore args))
   (uiop:run-program "clear" :output *standard-output*)
+  (when (> *debugger-level* 0)
+    (debugger-banner))
   (read-input))
 
 (define-magic help (&rest args)

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -104,6 +104,11 @@
       "nil")
     (error () (message-from-magic "No description given on `~a.`" target))))
 
+(define-magic cls (&rest args)
+  "Clear screen."
+  (declare (ignore args))
+  (uiop:run-program "clear" :output *standard-output*)
+  (read-input))
 
 (define-magic help (&rest args)
   "List available magic commands and usages."

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -79,6 +79,21 @@
         (message-from-magic "Error: Unexpected EOF.")
         code)))
 
+(define-magic expand (&rest forms)
+  "Alias to (macroexpand-1 (quote <form>))"
+  (let ((code (format nil "(macroexpand-1 '~{ ~a~})" forms)))
+    (if (line-continue-p code)
+        (message-from-magic "Error: Unexpected EOF.")
+        code)))
+
+(define-magic inspect (object &rest args)
+  "Alias to (inspect <object>)."
+  (declare (ignore args))
+  (let ((code (format nil "(inspect ~a)" object)))
+    (if (line-continue-p code)
+        (message-from-magic "Error: Unexpected EOF.")
+        code)))
+
 (define-magic step (&rest forms)
   "Alias to (step <form>)."
   (let ((code (format nil "(step ~{ ~a~})" forms)))

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -20,7 +20,9 @@
 (defun invoke-magic (magic &rest args)
   (loop :for (name body) :in *magic-commands*
         :when (string= name magic)
-        :do (return-from invoke-magic  (apply body args)))
+        :do (return-from invoke-magic
+              (handler-case (apply body args)
+                (error (c) (message-from-magic "Error: ~a" c)))))
   (message-from-magic "Command not found.: ~a" magic))
 
 (defun input-magic-p (&optional input)

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -90,6 +90,21 @@
   (handler-case (progn (setf *package* (find-package (read-from-string package))) "nil")
     (error () (message-from-magic "Failed to change package."))))
 
+(define-magic doc (target &rest args)
+  "Show description of given object."
+  (declare (ignore args))
+  (handler-case
+    (let ((s (make-array '(0)
+                         :element-type 'base-char
+                         :fill-pointer 0
+                         :adjustable t)))
+      (with-output-to-string (sb s)
+        (describe (read-from-string target) sb))
+      (invoke-pager s)
+      "nil")
+    (error () (message-from-magic "No description given on `~a.`" target))))
+
+
 (define-magic help (&rest args)
   "List available magic commands and usages."
   (declare (ignore args))

--- a/src/completer.lisp
+++ b/src/completer.lisp
@@ -33,11 +33,11 @@
 (defun select-completions (text items)
   (setf items
     (loop :for item :in items
-          :when (alexandria:starts-with-subseq text item)
+          :when (string-starts-with item text)
                 :collect item))
   (unless (cdr items)
     (setf rl:*completion-append-character*
-      (if (alexandria:ends-with-subseq ":" (car items)) #\nul #\space))
+      (if (string-ends-with (car items) ":") #\nul #\space))
     (return-from select-completions items))
   (cons
     (subseq (car items) 0

--- a/src/debugger.lisp
+++ b/src/debugger.lisp
@@ -5,7 +5,7 @@
 (defvar *selected-restart*)
 (defvar *backtrace-strings* nil)
 (defvar *redisplay-debugger-banner*)
-(defparameter *debugger-flush-screen* t)
+(defparameter *debugger-flush-screen* nil)
 
 (defun condition-string (condition)
   #+sbcl

--- a/src/debugger.lisp
+++ b/src/debugger.lisp
@@ -15,8 +15,7 @@
   (princ-to-string condition))
 
 (defun debugger-banner ()
-  (when *debugger-flush-screen*
-    (uiop:run-program "clear" :output *standard-output*))
+  (when *debugger-flush-screen* (flush-screen))
   (format t (color *condition-color* "~a~% [Condition of type ~a]~2%")
           (condition-string *current-condition*) (type-of *current-condition*))
   (format t (color *section-color* "Restarts:~%"))
@@ -100,8 +99,7 @@
     (let ((*debugger-hook* hook))
       (debugger-loop (1+ *debugger-level*)))
     (setf *redisplay-debugger-banner* t)
-    (when *debugger-flush-screen*
-      (uiop:run-program "clear" :output *standard-output*))
+    (when *debugger-flush-screen* (flush-screen))
     #+sbcl (pop *backtrace-strings*)
     (cl-repl/invoke-restart-interactively *selected-restart*)))
 

--- a/src/debugger.lisp
+++ b/src/debugger.lisp
@@ -18,6 +18,16 @@
   (format t (color *section-color* "Usage:~%"))
   (format t "  Ctrl+r: select restart. Ctrl+t: show backtrace.~2%"))
 
+#+sbcl
+(sb-ext:without-package-locks
+  (defun break (&optional (format-control "Break") &rest format-arguments)
+    (with-simple-restart (continue "Return from BREAK.")
+      (invoke-debugger
+        (make-condition 'simple-condition
+                        :format-control format-control
+                        :format-arguments format-arguments)))
+    nil))
+
 (defvar *current-condition*)
 (defvar *invokable-restarts*)
 (defvar *selected-restart*)

--- a/src/debugger.lisp
+++ b/src/debugger.lisp
@@ -16,11 +16,15 @@
         :for n :to (length choices)
         :do (format t "~2d: [~a] ~a~%"  n (restart-name choice) choice))
   (terpri)
-  (format t (color *section-color* "Bactrace:~%"))
-  (loop :for frame :in (split-sequence:split-sequence #\newline (car *backtrace-strings*))
-        :for n :from 0 :to 5
+  (format t (color *section-color* "Backtrace:~%"))
+  (loop :for frame :in (split-sequence:split-sequence
+                         #\newline
+                         (car *backtrace-strings*)
+                         :remove-empty-subseqs t)
+        :for n :from 0 :below 2
         :do (format t "~a~%" frame)
-        :finally (when (= n 5) (format t " --more-- ~%")))
+        :finally (when (= n 2) (format t " --more--~%")))
+  (terpri)
   (format t (color *section-color* "Usage:~%"))
   (format t "  Ctrl+r: select restart. Ctrl+t: show backtrace.~2%"))
 
@@ -66,7 +70,7 @@
         (format nil "~{~a~%~}"
           (loop :for f := stack-top-hint :then (sb-di:frame-down f)
                 :for n :from 0
-                :until (or (null f) (eql (sb-di:debug-fun-fun (sb-di:frame-debug-fun f)) #'cl-repl::eval-print))
+                :while f
                 :collect (let ((s (make-string-output-stream)))
                            (format s "~2d: " n)
                            (sb-debug::print-frame-call f s)

--- a/src/debugger.lisp
+++ b/src/debugger.lisp
@@ -70,16 +70,19 @@
 
 #+sbcl
 (defun push-backtrace-string ()
-  (push
-    (format nil "~{~a~%~}"
-      (loop :for f := sb-debug:*stack-top-hint* :then (sb-di:frame-down f)
-            :for n :from 0
-            :until (eql (sb-di:debug-fun-fun (sb-di:frame-debug-fun f)) #'cl-repl::eval-print)
-            :collect (let ((s (make-string-output-stream)))
-                       (format s "~2d: " n)
-                       (sb-debug::print-frame-call f s)
-                       (get-output-stream-string s))))
-    *backtrace-strings*))
+  (let ((stack-top-hint sb-debug:*stack-top-hint*))
+    (push
+      (if stack-top-hint
+        (format nil "~{~a~%~}"
+          (loop :for f := stack-top-hint :then (sb-di:frame-down f)
+                :for n :from 0
+                :until (or (null f) (eql (sb-di:debug-fun-fun (sb-di:frame-debug-fun f)) #'cl-repl::eval-print))
+                :collect (let ((s (make-string-output-stream)))
+                           (format s "~2d: " n)
+                           (sb-debug::print-frame-call f s)
+                           (get-output-stream-string s))))
+        "")
+      *backtrace-strings*)))
 
 (defun debugger (condition hook)
   (let ((*current-condition* condition)

--- a/src/debugger.lisp
+++ b/src/debugger.lisp
@@ -26,10 +26,7 @@
         :do (format t "~2d: [~a] ~a~%"  n (restart-name choice) choice))
   (terpri)
   (format t (color *section-color* "Backtrace:~%"))
-  (loop :for frame :in (split-sequence:split-sequence
-                         #\newline
-                         (car *backtrace-strings*)
-                         :remove-empty-subseqs t)
+  (loop :for frame :in (split-lines (car *backtrace-strings*))
         :for n :from 0 :below 2
         :do (format t "~a~%" frame)
         :finally (when (= n 2) (format t " --more--~%")))

--- a/src/debugger.lisp
+++ b/src/debugger.lisp
@@ -24,16 +24,6 @@
   (format t (color *section-color* "Usage:~%"))
   (format t "  Ctrl+r: select restart. Ctrl+t: show backtrace.~2%"))
 
-#+sbcl
-(sb-ext:without-package-locks
-  (defun break (&optional (format-control "Break") &rest format-arguments)
-    (with-simple-restart (*continue "Return from BREAK.")
-      (invoke-debugger
-       (make-condition 'simple-condition
-                       :format-control format-control
-                       :format-arguments format-arguments)))
-    nil))
-
 (defun cl-repl/compute-restarts (condition)
   (let ((restarts (compute-restarts condition))
         (flag-count 0))

--- a/src/debugger.lisp
+++ b/src/debugger.lisp
@@ -93,7 +93,6 @@
                 :do (progn (debugger-banner) (setf *redisplay-debugger-banner* nil)))))
 
 (defun debugger (condition hook)
-  (declare (ignore hook))
   (let ((*current-condition* condition)
         (*invokable-restarts* (cl-repl/compute-restarts condition)))
     (setf *selected-restart* nil
@@ -101,7 +100,8 @@
     #+sbcl (push-backtrace-string)
     (debugger-banner)
     (set-keymap "debugger")
-    (debugger-loop (1+ *debugger-level*))
+    (let ((*debugger-hook* hook))
+      (debugger-loop (1+ *debugger-level*)))
     (setf *redisplay-debugger-banner* t)
     (when *debugger-flush-screen*
       (uiop:run-program "clear" :output *standard-output*))

--- a/src/debugger.lisp
+++ b/src/debugger.lisp
@@ -1,10 +1,11 @@
 (in-package :cl-repl)
 
 (defun condition-string (condition)
-  (ppcre:regex-replace-all "(?<=\\.) "
-                           (ppcre:regex-replace-all "\\s\\s+"
-                                                    (format nil "~a" condition) " ")
-                           (string #\newline)))
+  #+sbcl
+  (let ((sb-int:*print-condition-references* nil))
+    (princ-to-string condition))
+  #-sbcl
+  (princ-to-string condition))
 
 (defun debugger-banner ()
   (format t (color *condition-color* "~a~% [Condition of type ~a]~2%")

--- a/src/debugger.lisp
+++ b/src/debugger.lisp
@@ -76,14 +76,14 @@
       (pop *backtrace-strings*)
       (cl-repl/invoke-restart-interactively *selected-restart*))))
 
-(defun invoke-restart-by-number (args key)
+(defun select-restart-by-number (args key)
   (declare (ignore args key))
   (format t "~%Restart number: ")
   (finish-output)
   (let ((rl:*done* t))
     (setf n (digit-char-p (rl:read-key))))  
-  (if (null n)
-      (format t "~%Please input number.~%")
+  (if (or (null n) (>= n (length *invokable-restarts*)))
+      (format t "~%Please input number below ~d.~%" (1- (length *invokable-restarts*)))
       (progn
         (terpri)
         (setf *selected-restart*
@@ -97,6 +97,6 @@
   (setf rl:*done* t))
 
 (define-keymap "debugger" ()
-  ("\\C-r" #'invoke-restart-by-number)
+  ("\\C-r" #'select-restart-by-number)
   ("\\C-t" #'show-backtrace))
 

--- a/src/debugger.lisp
+++ b/src/debugger.lisp
@@ -16,26 +16,27 @@
 
 (defun debugger-banner ()
   (when *debugger-flush-screen* (flush-screen))
-  (format t (color *condition-color* "~a~% [Condition of type ~a]~2%")
-          (condition-string *current-condition*) (type-of *current-condition*))
-  (format t (color *section-color* "Restarts:~%"))
-  (loop :with choices = *invokable-restarts*
-        :for choice :in choices
-        :for n :to (length choices)
-        :do (format t "~2d: [~a] ~a~%"  n (restart-name choice) choice))
-  (terpri)
-  (format t (color *section-color* "Backtrace:~%"))
-  (loop :for frame :in (split-lines (car *backtrace-strings*))
-        :for n :from 0 :below 2
-        :do (format t "~a~%" frame)
-        :finally (when (= n 2) (format t " --more--~%")))
-  (terpri)
-  (format t (color *section-color* "Usage:~%"))
-  (format t "  Ctrl+r: select restart. Ctrl+t: show backtrace.~%")
-  #+sbcl
-  (when (subtypep (type-of *current-condition*) 'sb-ext:step-condition)
-    (format t "  Ctrl+o: step-out. Ctrl+x: step-next, Ctrl+o: step-into.~%"))
-  (terpri))
+  (with-cursor-hidden
+    (format t (color *condition-color* "~a~% [Condition of type ~a]~2%")
+            (condition-string *current-condition*) (type-of *current-condition*))
+    (format t (color *section-color* "Restarts:~%"))
+    (loop :with choices = *invokable-restarts*
+          :for choice :in choices
+          :for n :to (length choices)
+          :do (format t "~2d: [~a] ~a~%"  n (restart-name choice) choice))
+    (terpri)
+    (format t (color *section-color* "Backtrace:~%"))
+    (loop :for frame :in (split-lines (car *backtrace-strings*))
+          :for n :from 0 :below 2
+          :do (format t "~a~%" frame)
+          :finally (when (= n 2) (format t " --more--~%")))
+    (terpri)
+    (format t (color *section-color* "Usage:~%"))
+    (format t "  Ctrl+r: select restart. Ctrl+t: show backtrace.~%")
+    #+sbcl
+    (when (subtypep (type-of *current-condition*) 'sb-ext:step-condition)
+      (format t "  Ctrl+o: step-out. Ctrl+x: step-next, Ctrl+o: step-into.~%"))
+    (terpri)))
 
 (defun cl-repl/compute-restarts (condition)
   (let ((restarts (compute-restarts condition))

--- a/src/debugger.lisp
+++ b/src/debugger.lisp
@@ -23,29 +23,39 @@
   (defun break (&optional (format-control "Break") &rest format-arguments)
     (with-simple-restart (*continue "Return from BREAK.")
       (invoke-debugger
-        (make-condition 'simple-condition
-                        :format-control format-control
-                        :format-arguments format-arguments)))
+       (make-condition 'simple-condition
+                       :format-control format-control
+                       :format-arguments format-arguments)))
     nil))
 
 (defun cl-repl/compute-restarts (condition)
   (let ((restarts (compute-restarts condition))
         (flag-count 0))
     (or
-      (flet ((supplied-by-cl-repl (r)
-                (ppcre:scan "CL-REPL" (format nil "~s" r))))
-        (loop :for restart :in restarts
-              :for count :from 0
-              :until (> flag-count 2)
-              :when (and (> count 0)
+     (flet ((supplied-by-cl-repl (r)
+              (ppcre:scan "CL-REPL" (format nil "~s" r))))
+       (loop :for restart :in restarts
+             :for count :from 0
+             :until (> flag-count 2)
+             :when (and (> count 0)
                         (or (supplied-by-cl-repl (nth (1- count) restarts))
                             (supplied-by-cl-repl restart)))
-                    :do (incf flag-count)
-              :when (and (zerop count)
-                         (supplied-by-cl-repl restart))
-                    :do (incf flag-count)
-              :collect restart))
-      restarts)))
+             :do (incf flag-count)
+             :when (and (zerop count)
+                        (supplied-by-cl-repl restart))
+             :do (incf flag-count)
+             :collect restart))
+     restarts)))
+
+(defun cl-repl/invoke-restart-interactively (restart)
+  (unless restart
+    (ignore-errors
+     (return-from cl-repl/invoke-restart-interactively (invoke-restart '*abort))))
+  (flet ((get-new-value () (read-from-string (rl:readline :prompt "value: "))))
+    (alexandria:switch ((string-downcase (restart-name restart)) :test #'string=)
+      ("store-value" (invoke-restart restart (get-new-value)))
+      ("use-value" (invoke-restart restart (get-new-value)))
+      (otherwise (invoke-restart-interactively restart)))))
 
 (defvar *current-condition*)
 (defvar *invokable-restarts*)
@@ -64,7 +74,7 @@
     (let ((*debugger-hook* hook))
       (repl :level (1+ *debugger-level*) :keymap "debugger")
       (pop *backtrace-strings*)
-      (invoke-restart-interactively (or *selected-restart* '*abort)))))
+      (cl-repl/invoke-restart-interactively *selected-restart*))))
 
 (defun invoke-restart-by-number (args key)
   (declare (ignore args key))

--- a/src/highlight.lisp
+++ b/src/highlight.lisp
@@ -55,16 +55,16 @@
                   :collect (or colored raw)))))
 
 (defun redisplay-with-highlight ()
-  (with-cursor-hidden
-    (format t "~c[2K~c~a~a~c[~aD"
-            #\esc
-            #\return
-            rl:*display-prompt*
-            (highlight-text rl:*line-buffer*)
-            #\esc
-            (- rl:+end+ rl:*point*))
-    (when (= rl:+end+ rl:*point*)
-      (format t "~c[1C" #\esc))))
+  (format t "~c[2K~c~a~a~c[~aD"
+          #\esc
+          #\return
+          rl:*display-prompt*
+          (highlight-text rl:*line-buffer*)
+          #\esc
+          (- rl:+end+ rl:*point*))
+  (when (= rl:+end+ rl:*point*)
+    (format t "~c[1C" #\esc))
+  (finish-output))
 
 (defvar *syntax-enabled* nil)
 

--- a/src/highlight.lisp
+++ b/src/highlight.lisp
@@ -21,6 +21,7 @@
         :finally (return (list functions specials)))
   (defvar *syntax-table*
     (list
+     :magic (list *magic-syntax-color* "^%.*")
      :string (list *string-syntax-color* "\".*?\"")
      :variable (list *variable-syntax-color* "([\\*])\\S+\\1")
      :constant (list *constant-syntax-color* "([\\+])\\S+\\1")

--- a/src/highlight.lisp
+++ b/src/highlight.lisp
@@ -55,16 +55,16 @@
                   :collect (or colored raw)))))
 
 (defun redisplay-with-highlight ()
-  (format t "~c[2K~c~a~a~c[~aD"
-          #\esc
-          #\return
-          rl:*display-prompt*
-          (highlight-text rl:*line-buffer*)
-          #\esc
-          (- rl:+end+ rl:*point*))
-  (when (= rl:+end+ rl:*point*)
-    (format t "~c[1C" #\esc))
-  (finish-output))
+  (with-cursor-hidden
+    (format t "~c[2K~c~a~a~c[~aD"
+            #\esc
+            #\return
+            rl:*display-prompt*
+            (highlight-text rl:*line-buffer*)
+            #\esc
+            (- rl:+end+ rl:*point*))
+    (when (= rl:+end+ rl:*point*)
+      (format t "~c[1C" #\esc))))
 
 (defvar *syntax-enabled* nil)
 

--- a/src/highlight.lisp
+++ b/src/highlight.lisp
@@ -66,8 +66,12 @@
     (format t "~c[1C" #\esc))
   (finish-output))
 
+(defvar *syntax-enabled* nil)
+
 (defun enable-syntax ()
+  (setf *syntax-enabled* t)
   (rl:register-function :redisplay #'redisplay-with-highlight))
 
 (defun disable-syntax ()
+  (setf *syntax-enabled* nil)
   (rl:register-function :redisplay #'rl:redisplay))

--- a/src/input.lisp
+++ b/src/input.lisp
@@ -34,11 +34,7 @@
 (defun check-input (input)
   (when (input-magic-p input)
     (setf *last-input*
-          (apply #'invoke-magic
-                 (split-sequence:split-sequence
-                  #\SPACE
-                  input
-                  :remove-empty-subseqs t)))
+          (apply #'invoke-magic (split-space input)))
     (return-from check-input))
   (when (shell-command-p input)
     (setf *last-input* "nil")

--- a/src/input.lisp
+++ b/src/input.lisp
@@ -40,16 +40,14 @@
     (setf *last-input* "nil")
     (run-shell-command input)
     (return-from check-input))
-  (alexandria:switch
-      (input :test #'equal)
+  (string-case input
     ("" (setf *last-input* "nil"))
     (nil (progn (format t "~%") (exit-with-prompt)))
-    (t (setf *last-input* input))))
+    (otherwise (setf *last-input* input))))
 
 (defun read-input1 (&key (multiline-p nil))
   (finish-output)
   (rl:readline :prompt (prompt :multiline-p multiline-p)
-               ;                :add-history (zerop *debugger-level*)))
                :add-history t))
 
 (defun read-input ()

--- a/src/inspector.lisp
+++ b/src/inspector.lisp
@@ -48,8 +48,11 @@
   (set-keymap "inspector")
   (setf *inspector-state* nil
         *inspector-redisplay-banner* nil)
+  (format t "~c[?25l" #\escape)
   (catch 'inspector-quit
-    (inspect-one object))
+    (unwind-protect
+      (inspect-one object)
+      (format t "~c[?25h" #\escape)))
   (when *inspector-flush-screen*
     (uiop:run-program "clear" :output *standard-output*)
     (read-input)))

--- a/src/inspector.lisp
+++ b/src/inspector.lisp
@@ -5,7 +5,7 @@
 (defvar *inspect-named-p*)
 (defvar *inspector-state*)
 (defvar *inspector-redisplay-banner*)
-(defparameter *inspector-flush-screen* t)
+(defparameter *inspector-flush-screen* nil)
 
 (defun inspector-banner ()
   (when *inspector-flush-screen* (flush-screen))

--- a/src/inspector.lisp
+++ b/src/inspector.lisp
@@ -1,0 +1,97 @@
+(in-package :cl-repl)
+
+(defvar *inspected*)
+(defvar *inspect-elements*)
+(defvar *inspect-named-p*)
+(defvar *inspector-state*)
+(defvar *inspector-redisplay-banner*)
+(defparameter *inspector-flush-screen* t)
+
+(defun inspector-banner ()
+  (when *inspector-flush-screen*
+    (uiop:run-program "clear" :output *standard-output*))
+  #+sbcl
+  (destructuring-bind (description named-p elements)
+    (multiple-value-list (sb-impl::inspected-parts *inspected*))
+    (setf *inspect-named-p* named-p)
+    (setf *inspect-elements* elements)
+    (format t "~a~%" (color  *condition-color* description))
+    (format t (color *section-color* "Slots:~%"))
+    (loop :for elm :in elements
+          :for n :from 0
+          :do (format t "~2d. ~a~%" n elm)))
+  (terpri)
+  (format t (color *section-color* "Usage:~%"))
+  (format t "  q: quit. 0~~9: inspect the numbered slot.~2%"))
+
+(defun inspector-process-key ()
+  (rl:register-function :redisplay #'(lambda () nil))
+  (unwind-protect
+    (rl:readline)
+    (if *syntax-enabled*
+      (enable-syntax)
+      (disable-syntax))))
+
+(defun inspect-one (object)
+  (let ((*inspected* object)
+        (*inspector-state*))
+    (inspector-banner)
+    (loop :until *inspector-state*
+          :when *inspector-redisplay-banner*
+                :do (progn
+                      (inspector-banner)
+                      (setf *inspector-redisplay-banner* nil))
+          :do (inspector-process-key))))
+
+(defun inspector (object &rest args)
+  (declare (ignore args))
+  (set-keymap "inspector")
+  (setf *inspector-state* nil
+        *inspector-redisplay-banner* nil)
+  (catch 'inspector-quit
+    (inspect-one object))
+  (when *inspector-flush-screen*
+    (uiop:run-program "clear" :output *standard-output*)
+    (read-input)))
+
+(defun inspector-quit (args key)
+  (declare (ignore args key))
+  (throw 'inspector-quit nil))
+
+(defun inspector-move-to-previous (args key)
+  (declare (ignore args key))
+  (setf rl:*done* t
+        *inspector-state* t
+        *inspector-redisplay-banner* t))
+
+(defun inspector-select (args key)
+  (declare (ignore args key))
+  (setf rl:*done* t)
+  #+sbcl
+  (let ((n (digit-char-p key)))
+    (when (and n (< -1 n (length *inspect-elements*)))
+      (let* ((element (nth n *inspect-elements*))
+             (value (if *inspect-named-p* (cdr element) element)))
+        (if (eq value sb-impl::*inspect-unbound-object-marker*)
+            (format t (color *condition-color* "That slot is unbound.~%"))
+            (inspect-one value))))))
+
+(define-keymap "inspector" ()
+  (#\q #'inspector-quit)
+  (#\e #'inspector-quit)
+  (#\u #'inspector-move-to-previous)
+  (#\0 #'inspector-select)
+  (#\1 #'inspector-select)
+  (#\2 #'inspector-select)
+  (#\3 #'inspector-select)
+  (#\4 #'inspector-select)
+  (#\5 #'inspector-select)
+  (#\6 #'inspector-select)
+  (#\7 #'inspector-select)
+  (#\8 #'inspector-select)
+  (#\9 #'inspector-select)
+  (#\RETURN #'unbind-key))
+
+(defun install-inspector ()
+  #+sbcl
+  (setf sb-impl::*inspect-fun* #'inspector))

--- a/src/inspector.lisp
+++ b/src/inspector.lisp
@@ -55,7 +55,11 @@
       (format t "~c[?25h" #\escape)))
   (when *inspector-flush-screen*
     (uiop:run-program "clear" :output *standard-output*)
-    (read-input)))
+    (if (zerop *debugger-level*)
+        (set-keymap "default")
+        (progn
+          (set-keymap "debugger")
+          (debugger-banner)))))
 
 (defun inspector-quit (args key)
   (declare (ignore args key))

--- a/src/inspector.lisp
+++ b/src/inspector.lisp
@@ -9,19 +9,20 @@
 
 (defun inspector-banner ()
   (when *inspector-flush-screen* (flush-screen))
-  #+sbcl
-  (destructuring-bind (description named-p elements)
-    (multiple-value-list (sb-impl::inspected-parts *inspected*))
-    (setf *inspect-named-p* named-p)
-    (setf *inspect-elements* elements)
-    (format t "~a~%" (color  *condition-color* description))
-    (format t (color *section-color* "Slots:~%"))
-    (loop :for elm :in elements
-          :for n :from 0
-          :do (format t "~2d. ~a~%" n elm)))
-  (terpri)
-  (format t (color *section-color* "Usage:~%"))
-  (format t "  q: quit. 0~~9: inspect the numbered slot.~2%"))
+  (with-cursor-hidden
+    #+sbcl
+    (destructuring-bind (description named-p elements)
+      (multiple-value-list (sb-impl::inspected-parts *inspected*))
+      (setf *inspect-named-p* named-p)
+      (setf *inspect-elements* elements)
+      (format t "~a~%" (color  *condition-color* description))
+      (format t (color *section-color* "Slots:~%"))
+      (loop :for elm :in elements
+            :for n :from 0
+            :do (format t "~2d. ~a~%" n elm)))
+    (terpri)
+    (format t (color *section-color* "Usage:~%"))
+    (format t "  q: quit. 0~~9: inspect the numbered slot.~2%")))
 
 (defun inspector-process-key ()
   (rl:register-function :redisplay #'(lambda () nil))

--- a/src/inspector.lisp
+++ b/src/inspector.lisp
@@ -8,8 +8,7 @@
 (defparameter *inspector-flush-screen* t)
 
 (defun inspector-banner ()
-  (when *inspector-flush-screen*
-    (uiop:run-program "clear" :output *standard-output*))
+  (when *inspector-flush-screen* (flush-screen))
   #+sbcl
   (destructuring-bind (description named-p elements)
     (multiple-value-list (sb-impl::inspected-parts *inspected*))
@@ -54,7 +53,7 @@
       (inspect-one object)
       (format t "~c[?25h" #\escape)))
   (when *inspector-flush-screen*
-    (uiop:run-program "clear" :output *standard-output*)
+    (flush-screen)
     (if (zerop *debugger-level*)
         (set-keymap "default")
         (progn

--- a/src/keymap.lisp
+++ b/src/keymap.lisp
@@ -1,5 +1,6 @@
 (in-package :cl-repl)
 
+(defvar *keymap*)
 (defvar *keymaps* (make-hash-table :test 'equal))
 (defvar *rl-default-keymap* (rl:get-keymap))
 

--- a/src/keymap.lisp
+++ b/src/keymap.lisp
@@ -21,7 +21,8 @@
   (gethash name *keymaps*))
 
 (define-keymap "default" ()
-  ("\\C-r" #'unbind-key))
+  ("\\C-r" #'unbind-key)
+  ("\\C-s" #'unbind-key))
 
 (defun set-keymap (name)
   (let ((keymap (find-keymap name)))

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -35,7 +35,7 @@
         (format *error-output* "Failed to load ~a, quitting.~%[~a]~%" *site-init-path* c)
         (uiop:quit 1)))))
 
-(defparameter *repl-flush-screen* t)
+(defparameter *repl-flush-screen* nil)
 
 (defmacro when-option ((options opt) &body body)
   `(let ((it (getf ,options ,opt)))

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -56,7 +56,8 @@
 
 (progn
   (enable-syntax)
-  (rl:register-function :complete #'completer))
+  (rl:register-function :complete #'completer)
+  (install-inspector))
 
 (defun main (&optional argv &key (show-logo t))
   (multiple-value-bind (options free-args)

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -79,9 +79,10 @@
       (setf *site-init-path* nil)))
   (site-init)
   (when *repl-flush-screen* (flush-screen))
-  (when show-logo
-    (format t (color *logo-color* *logo*)))
-  (format t "~a~%~a~2%" *versions* *copy*)
+  (with-cursor-hidden
+    (when show-logo
+      (format t (color *logo-color* *logo*)))
+    (format t "~a~%~a~2%" *versions* *copy*))
   (in-package :cl-user)
   (unwind-protect
     (conium:call-with-debugger-hook #'debugger #'repl)

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -1,6 +1,6 @@
 (in-package :cl-repl)
 
-(defconstant +version+ '0.5.1)
+(defconstant +version+ '0.6.0)
 
 (defvar *logo*
   "  ___  __          ____  ____  ____  __

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -55,9 +55,6 @@
    :long "no-init"))
 
 (progn
-  #+sbcl
-  (sb-ext:enable-debugger)
-  (conium:install-debugger-globally #'debugger)
   (enable-syntax)
   (rl:register-function :complete #'completer))
 
@@ -83,6 +80,6 @@
   (format t "~a~%~a~2%" *versions* *copy*)
   (in-package :cl-user)
   (unwind-protect
-    (repl)
+    (conium:call-with-debugger-hook #'debugger #'repl)
     (rl:deprep-terminal)))
 

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -54,6 +54,13 @@
    :short #\n
    :long "no-init"))
 
+(progn
+  #+sbcl
+  (sb-ext:enable-debugger)
+  (conium:install-debugger-globally #'debugger)
+  (enable-syntax)
+  (rl:register-function :complete #'completer))
+
 (defun main (&optional argv &key (show-logo t))
   (multiple-value-bind (options free-args)
       (handler-case
@@ -70,14 +77,12 @@
       (uiop:quit 0))
     (when-option (options :no-init)
       (setf *site-init-path* nil)))
-  (enable-syntax)
   (site-init)
   (when show-logo
     (format t (color *logo-color* *logo*)))
   (format t "~a~%~a~2%" *versions* *copy*)
-  #+sbcl (sb-ext:enable-debugger)
-  (rl:register-function :complete #'completer)
   (in-package :cl-user)
-  (repl)
-  (rl:deprep-terminal))
+  (unwind-protect
+    (repl)
+    (rl:deprep-terminal)))
 

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -1,6 +1,6 @@
 (in-package :cl-repl)
 
-(defconstant +version+ '0.5.0)
+(defconstant +version+ '0.5.1)
 
 (defvar *logo*
   "  ___  __          ____  ____  ____  __

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -78,8 +78,7 @@
     (when-option (options :no-init)
       (setf *site-init-path* nil)))
   (site-init)
-  (when *repl-flush-screen*
-    (uiop:run-program "clear" :output *standard-output*))
+  (when *repl-flush-screen* (flush-screen))
   (when show-logo
     (format t (color *logo-color* *logo*)))
   (format t "~a~%~a~2%" *versions* *copy*)
@@ -87,7 +86,6 @@
   (unwind-protect
     (conium:call-with-debugger-hook #'debugger #'repl)
     (rl:deprep-terminal))
-  (when *repl-flush-screen*
-    (uiop:run-program "clear" :output *standard-output*)))
+  (when *repl-flush-screen* (flush-screen)))
 
 

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -35,6 +35,8 @@
         (format *error-output* "Failed to load ~a, quitting.~%[~a]~%" *site-init-path* c)
         (uiop:quit 1)))))
 
+(defparameter *repl-flush-screen* t)
+
 (defmacro when-option ((options opt) &body body)
   `(let ((it (getf ,options ,opt)))
      (when it
@@ -76,11 +78,16 @@
     (when-option (options :no-init)
       (setf *site-init-path* nil)))
   (site-init)
+  (when *repl-flush-screen*
+    (uiop:run-program "clear" :output *standard-output*))
   (when show-logo
     (format t (color *logo-color* *logo*)))
   (format t "~a~%~a~2%" *versions* *copy*)
   (in-package :cl-user)
   (unwind-protect
     (conium:call-with-debugger-hook #'debugger #'repl)
-    (rl:deprep-terminal)))
+    (rl:deprep-terminal))
+  (when *repl-flush-screen*
+    (uiop:run-program "clear" :output *standard-output*)))
+
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -9,6 +9,7 @@
            disable-syntax
            *pager-command*
            *pager-minimum-line-count*
+           *pager-flush-screen*
            *default-prompt-function*
            *debugger-prompt-function*
            *output-indicator-function*

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -13,7 +13,10 @@
            *default-prompt-function*
            *debugger-prompt-function*
            *output-indicator-function*
-           *debugger-level*))
+           *debugger-level*
+           *repl-flush-screen*
+           *debugger-flush-screen*
+           *inspector-flush-screen*))
 
 (defpackage :repl-user
   (:use :cl :cl-repl))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -7,6 +7,8 @@
            define-color-scheme
            color-scheme
            disable-syntax
+           *pager-command*
+           *pager-minimum-line-count*
            *default-prompt-function*
            *debugger-prompt-function*
            *output-indicator-function*

--- a/src/pager.lisp
+++ b/src/pager.lisp
@@ -1,0 +1,23 @@
+(in-package :cl-repl)
+
+(defparameter *pager-command* "less")
+(defparameter *pager-minimum-line-count* 10)
+
+(defun probe-pager-command ()
+  (handler-case
+      (progn
+        (uiop:run-program
+         (format nil "command -v ~a" *pager-command*))
+        t)
+    (error () nil)))
+
+(defun invoke-pager (text)
+  (if (and (probe-pager-command)
+           (> (/ (length (ppcre:all-matches "\\n" text)) 2)
+              *pager-minimum-line-count*))
+      (uiop:run-program
+       (format nil "echo ~s | ~a" text *pager-command*)
+       :ignore-error-status t
+       :input :interactive
+       :output :interactive)
+      (format t text)))

--- a/src/pager.lisp
+++ b/src/pager.lisp
@@ -2,6 +2,7 @@
 
 (defparameter *pager-command* "less")
 (defparameter *pager-minimum-line-count* 10)
+(defparameter *pager-flush-screen* t)
 
 (defun probe-pager-command ()
   (handler-case
@@ -16,7 +17,10 @@
            (> (/ (length (ppcre:all-matches "\\n" text)) 2)
               *pager-minimum-line-count*))
       (uiop:run-program
-       (format nil "echo ~s | ~a" text *pager-command*)
+       (format nil "~a echo ~s | ~a"
+         (if *pager-flush-screen* "clear; " "")
+         text
+         *pager-command*)
        :ignore-error-status t
        :input :interactive
        :output :interactive)

--- a/src/repl.lisp
+++ b/src/repl.lisp
@@ -5,12 +5,13 @@
 (defun exit-with-prompt ()
   (finish-output)
   (when (zerop *debugger-level*)
-    (alexandria:switch
-        ((rl:readline :prompt "Do you really want to exit ([y]/n)? ")
-         :test #'equal)
-      (nil (terpri)) ("") ("y")
+    (string-case
+      (rl:readline :prompt "Do you really want to exit ([y]/n)? ")
+      (nil (terpri))
+      ("")
+      ("y")
       ("n" (return-from exit-with-prompt (setf *last-input* "nil")))
-      (t (exit-with-prompt))))
+      (otherwise (return-from exit-with-prompt (exit-with-prompt)))))
   (throw *debugger-level* nil))
 
 (defvar *output-indicator-function*

--- a/src/repl.lisp
+++ b/src/repl.lisp
@@ -35,13 +35,14 @@
      (*exit () :report "Exit CL-REPL." (throw 0 nil))
      ,@restarts))
 
-(defun read-eval-print ()
-  (with-extra-restarts
-    (eval-print (setq - (read-from-string (read-input))))
-    (*retry () :report "Try evaluating again."
-      (with-extra-restarts (eval-print -)))))
+(defun read-eval-print (&key (level 0))
+  (let ((*debugger-level* level))
+    (with-extra-restarts
+      (eval-print (setq - (read-from-string (read-input))))
+      (*retry () :report "Try evaluating again."
+        (with-extra-restarts (eval-print -))))))
 
-(defun repl (&key package (level 0) (keymap "default"))
-  (loop :with *debugger-level* := level
-        :do (set-keymap keymap)
-        :while (catch level (read-eval-print))))
+(defun repl ()
+  (loop :do (set-keymap "default")
+        :while (catch 0 (read-eval-print))))
+ 

--- a/src/repl.lisp
+++ b/src/repl.lisp
@@ -36,11 +36,10 @@
      ,@restarts))
 
 (defun read-eval-print ()
-  (let ((*debugger-hook* #'debugger))
-    (with-extra-restarts
-      (eval-print (setq - (read-from-string (read-input))))
-      (*retry () :report "Try evaluating again."
-                 (with-extra-restarts (eval-print -))))))
+  (with-extra-restarts
+    (eval-print (setq - (read-from-string (read-input))))
+    (*retry () :report "Try evaluating again."
+      (with-extra-restarts (eval-print -)))))
 
 (defun repl (&key package (level 0) (keymap "default"))
   (loop :with *debugger-level* := level

--- a/src/repl.lisp
+++ b/src/repl.lisp
@@ -43,6 +43,7 @@
         (with-extra-restarts (eval-print -))))))
 
 (defun repl ()
-  (loop :do (set-keymap "default")
+  (loop :when (string/= *keymap* "default")
+              :do (set-keymap "default")
         :while (catch 0 (read-eval-print))))
  

--- a/src/shell.lisp
+++ b/src/shell.lisp
@@ -1,7 +1,7 @@
 (in-package :cl-repl)
 
 (defun shell-command-p (&optional input)
-  (alexandria:starts-with-subseq "!" input))
+  (string-starts-with input "!"))
 
 (defun run-shell-command (cmd)
   (uiop:run-program (subseq cmd 1) :output *standard-output*))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -24,8 +24,11 @@
   `(unwind-protect
      (progn
        (format t "~c[?25l" #\esc)
+       (finish-output)
        ,@body)
-     (format t "~c[?25h" #\esc)))
+     (progn
+       (format t "~c[?25h" #\esc)
+       (finish-output))))
 
 (defun flush-screen ()
   (with-cursor-hidden

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -1,0 +1,37 @@
+(in-package :cl-repl)
+
+(defun split-lines (text)
+  (ppcre:split "\\n+" text))
+
+(defun split-space (text)
+  (ppcre:split "\\s+" text))
+
+(defun string-starts-with (str prefix)
+  (when (>= (length str) (length prefix))
+    (string= str prefix :start1 0 :end1 (length prefix))))
+  
+(defun string-ends-with (str suffix)
+ (when (>= (length str) (length suffix))
+   (string= str suffix :start1 (- (length str) (length suffix)))))
+
+(defmacro string-case (str &rest forms)
+  `(case (intern ,str)
+     ,@(loop :for (s f) :in forms
+             :if (stringp s) :collect `(,(intern s) ,f)
+             :else :collect `(,s ,f))))
+
+(defmacro with-cursor-hidden (&body body)
+  `(unwind-protect
+     (progn
+       (format t "~c[?25l" #\esc)
+       ,@body)
+     (format t "~c[?25h" #\esc)))
+
+(defun flush-screen ()
+  (with-cursor-hidden
+    (format t "~c[H~@*~c[j" #\esc)
+    (finish-output)))
+
+
+
+

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -29,7 +29,7 @@
 
 (defun flush-screen ()
   (with-cursor-hidden
-    (format t "~c[H~@*~c[j" #\esc)
+    (format t "~c[2J~@*~c[;H" #\esc)
     (finish-output)))
 
 


### PR DESCRIPTION
## Added
- Support external pager (#29)
- Interactive inspector (#33) & `%inspect` (b548e8e)
- Step execution & `%step` (e83fc9a, a6a694c)
- Some magics (#31, a6a694c, b548e8e)
- Clear screen when invoking repl, debugger or inspector.
  This can be enabled by setting `*repl/debugger/inspactor-flush-screen*` to `t`. (default: nil)

And some bug fixes.