### PR TITLE
Improve and add magic commands

### DIFF
--- a/src/command.lisp
+++ b/src/command.lisp
@@ -104,6 +104,11 @@
       "nil")
     (error () (message-from-magic "No description given on `~a.`" target))))
 
+(define-magic cls (&rest args)
+  "Clear screen."
+  (declare (ignore args))
+  (uiop:run-program "clear" :output *standard-output*)
+  (read-input))
 
 (define-magic help (&rest args)
   "List available magic commands and usages."

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -20,7 +20,9 @@
 (defun invoke-magic (magic &rest args)
   (loop :for (name body) :in *magic-commands*
         :when (string= name magic)
-        :do (return-from invoke-magic  (apply body args)))
+        :do (return-from invoke-magic
+              (handler-case (apply body args)
+                (error (c) (message-from-magic "Error: ~a" c)))))
   (message-from-magic "Command not found.: ~a" magic))
 
 (defun input-magic-p (&optional input)

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -90,6 +90,21 @@
   (handler-case (progn (setf *package* (find-package (read-from-string package))) "nil")
     (error () (message-from-magic "Failed to change package."))))
 
+(define-magic doc (target &rest args)
+  "Show description of given object."
+  (declare (ignore args))
+  (handler-case
+    (let ((s (make-array '(0)
+                         :element-type 'base-char
+                         :fill-pointer 0
+                         :adjustable t)))
+      (with-output-to-string (sb s)
+        (describe (read-from-string target) sb))
+      (invoke-pager s)
+      "nil")
+    (error () (message-from-magic "No description given on `~a.`" target))))
+
+
 (define-magic help (&rest args)
   "List available magic commands and usages."
   (declare (ignore args))


### PR DESCRIPTION
## Added
- %python, %perl, %ruby  
These commands execute given line with according external interpreter.
- %cls  
Clear the screen.
- %doc  
Show description of given symbol, using `less`.

## Changed
- %load, %package  
Add messages while executing.
- Handle errors which are not handled by magics.
