### PR TITLE
Fix style-warnings, like 'undefined variable'.

### DIFF
--- a/src/keymap.lisp
+++ b/src/keymap.lisp
@@ -6,8 +6,7 @@
 
 (defmacro define-keymap (name (&optional parent) &body bindings)
   (let ((keymap (gensym)))
-    `(progn 
-       (setf ,keymap (rl:copy-keymap (or (find-keymap ,parent) *rl-default-keymap*)))
+    `(let ((,keymap (rl:copy-keymap (or (find-keymap ,parent) *rl-default-keymap*))))
        (loop :for (key func) :in ',bindings
              :when (stringp key)
              :do (rl:bind-keyseq key (eval func) :keymap ,keymap)
@@ -24,7 +23,9 @@
 (define-keymap "default" ()
   ("\\C-r" #'unbind-key)
   ("\\C-s" #'unbind-key)
-  ("\\C-l" (lambda (&rest args) (invoke-magic "%cls"))))
+  ("\\C-l" (lambda (&rest args)
+             (declare (ignore args))
+             (invoke-magic "%cls"))))
 
 (defun set-keymap (name)
   (let ((keymap (find-keymap name)))


### PR DESCRIPTION
Fix style-warnings when loading cl-repl with SBCL (I tried with v1.4.7).

Here's logs:
```
CL-USER> (ql:quickload :cl-repl)
To load "cl-repl":
  Load 1 ASDF system:
    cl-repl
; Loading "cl-repl"
; compiling file "/Users/fukamachi/.roswell/local-projects/koji-kojiro/cl-repl/src/keymap.lisp" (written 08 JUN 2018 02:49:59 PM):
; compiling (IN-PACKAGE :CL-REPL)
; compiling (DEFVAR *KEYMAP*)
; compiling (DEFVAR *KEYMAPS* ...)
; compiling (DEFVAR *RL-DEFAULT-KEYMAP* ...)
; compiling (DEFMACRO DEFINE-KEYMAP ...)
; compiling (DEFUN UNBIND-KEY ...)
; compiling (DEFUN FIND-KEYMAP ...)
; compiling (DEFINE-KEYMAP "default" ...)
; compiling (DEFUN SET-KEYMAP ...)
; compiling (SET-KEYMAP "default")

; /Users/fukamachi/.cache/common-lisp/sbcl-1.4.7-macosx-x64/Users/fukamachi/.roswell/local-projects/koji-kojiro/cl-repl/src/keymap-tmp5GEXGEG5.fasl written
; compilation finished in 0:00:00.008
; in: LAMBDA (&REST ARGS)
;     (LAMBDA (&REST CL-REPL::ARGS) (CL-REPL::INVOKE-MAGIC "%cls"))
; 
; caught STYLE-WARNING:
;   The variable ARGS is defined but never used.
; compiling file "/Users/fukamachi/.roswell/local-projects/koji-kojiro/cl-repl/src/debugger.lisp" (written 08 JUN 2018 02:49:59 PM):
; compiling (IN-PACKAGE :CL-REPL)
; compiling (DEFVAR *CURRENT-CONDITION*)
; compiling (DEFVAR *INVOKABLE-RESTARTS*)
; compiling (DEFVAR *SELECTED-RESTART*)
; compiling (DEFVAR *BACKTRACE-STRINGS* ...)
; compiling (DEFVAR *REDISPLAY-DEBUGGER-BANNER*)
; compiling (DEFPARAMETER *DEBUGGER-FLUSH-SCREEN* ...)
; compiling (DEFUN CONDITION-STRING ...)
; compiling (DEFUN DEBUGGER-BANNER ...).
; compiling (DEFUN CL-REPL/COMPUTE-RESTARTS ...)
; compiling (DEFUN CL-REPL/INVOKE-RESTART-INTERACTIVELY ...)
; compiling (DEFUN PUSH-BACKTRACE-STRING ...)
; compiling (DEFUN DEBUGGER-LOOP ...)
; compiling (DEFUN DEBUGGER ...)
; compiling (DEFUN SELECT-RESTART-BY-NUMBER ...)

; file: /Users/fukamachi/.roswell/local-projects/koji-kojiro/cl-repl/src/debugger.lisp
; in: DEFUN SELECT-RESTART-BY-NUMBER
;     (LET ((CL-READLINE:*DONE* T))
;       (SETF CL-REPL::N (DIGIT-CHAR-P (CL-READLINE:READ-KEY))))
; 
; caught STYLE-WARNING:
;   using the lexical binding of the symbol (CL-READLINE:*DONE*), not the
;   dynamic binding, even though the name follows
;   the usual naming convention (names like *FOO*) for special variables
; 
; caught STYLE-WARNING:
;   The variable CL-READLINE:*DONE* is defined but never used.

; compiling (DEFUN SHOW-BACKTRACE ...)
; compiling (DEFMACRO SET-RESTART ...)
; compiling (DEFUN STEP-OUT ...)
; compiling (DEFUN STEP-NEXT ...)
; compiling (DEFUN STEP-INTO ...)
; compiling (DEFINE-KEYMAP "debugger" ...).

; /Users/fukamachi/.cache/common-lisp/sbcl-1.4.7-macosx-x64/Users/fukamachi/.roswell/local-projects/koji-kojiro/cl-repl/src/debugger-tmpAR3FSGEY.fasl written
; compilation finished in 0:00:00.078
WARNING:
   Lisp compilation had style-warnings while
   compiling #<CL-SOURCE-FILE "cl-repl" "src" "debugger">

; file: /Users/fukamachi/.roswell/local-projects/koji-kojiro/cl-repl/src/debugger.lisp
; in: CL-REPL::DEFINE-KEYMAP "debugger"
;     (CL-REPL::DEFINE-KEYMAP "debugger"
;         NIL
;       ("\\C-r" #'CL-REPL::SELECT-RESTART-BY-NUMBER)
;       ("\\C-o" #'CL-REPL::STEP-OUT)
;       ("\\C-x" #'CL-REPL::STEP-NEXT)
;       ("\\C-s" #'CL-REPL::STEP-INTO)
;       ("\\C-t" #'CL-REPL::SHOW-BACKTRACE))
; --> PROGN SETF SETQ 
; ==>
;   (SETQ #:G0
;           (CL-READLINE:COPY-KEYMAP
;            (OR (CL-REPL::FIND-KEYMAP NIL) CL-REPL::*RL-DEFAULT-KEYMAP*)))
; 
; caught WARNING:
;   undefined variable: #:G0

; in: DEFUN CL-REPL::STEP-INTO
;     (CL-REPL::SET-RESTART 'STEP-INTO)
; --> PROGN SETF 
; ==>
;   (SETQ #:G0 (FIND-RESTART 'STEP-INTO))
; 
; caught WARNING:
;   undefined variable: #:G0

; in: DEFUN CL-REPL::STEP-NEXT
;     (CL-REPL::SET-RESTART 'STEP-NEXT)
; --> PROGN SETF 
; ==>
;   (SETQ #:G0 (FIND-RESTART 'STEP-NEXT))
; 
; caught WARNING:
;   undefined variable: #:G0


; file: /Users/fukamachi/.roswell/local-projects/koji-kojiro/cl-repl/src/keymap.lisp
; in: CL-REPL::DEFINE-KEYMAP "default"
;     (CL-REPL::DEFINE-KEYMAP "default"
;         NIL
;       ("\\C-r" #'CL-REPL::UNBIND-KEY)
;       ("\\C-s" #'CL-REPL::UNBIND-KEY)
;       ("\\C-l" (LAMBDA (&REST CL-REPL::ARGS) (CL-REPL::INVOKE-MAGIC "%cls"))))
; --> PROGN SETF SETQ 
; ==>
;   (SETQ #:G0
;           (CL-READLINE:COPY-KEYMAP
;            (OR (CL-REPL::FIND-KEYMAP NIL) CL-REPL::*RL-DEFAULT-KEYMAP*)))
; 
; caught WARNING:
;   undefined variable: #:G0


; file: /Users/fukamachi/.roswell/local-projects/koji-kojiro/cl-repl/src/debugger.lisp
; in: DEFUN CL-REPL::SELECT-RESTART-BY-NUMBER
;     (SETF CL-REPL::N (DIGIT-CHAR-P (CL-READLINE:READ-KEY)))
; ==>
;   (SETQ CL-REPL::N (DIGIT-CHAR-P (CL-READLINE:READ-KEY)))
; 
; caught WARNING:
;   undefined variable: CL-REPL::N
; 
; compilation unit finished
;   Undefined variables:
;     #:G0 #:G0 #:G0 #:G0 CL-REPL::N
;   caught 5 WARNING conditions
;   caught 3 STYLE-WARNING conditions

(:CL-REPL)
CL-USER> 
```