### PR TITLE
Fix Memory Corruption Unhandled Memory fault at #x0

### DIFF
--- a/src/highlight.lisp
+++ b/src/highlight.lisp
@@ -56,6 +56,7 @@
                   :collect (or colored raw)))))
 
 (defun redisplay-with-highlight ()
+  (rl:redisplay)
   (format t "~c[2K~c~a~a~c[~aD"
           #\esc
           #\return


### PR DESCRIPTION
It seems that `rl:redisplay` initializes  some C pointer which is not
properly setup when is overridden by `enable-syntax`, that way a
`SIGSEGV` signal raises and the signal is handled before. Using
`strace ros repl` it's possible to check that.

Calling `(rl:redisplay)` on the beginning of
`redisplay-with-highlight` function, which is used
when `(enable-syntax)` is called, fix that issue.

That is some mistery to me yet, I look directly on cl-readline and GNU
readline C code but it's not clear what is going here.

Proof of working:

![fix-of-the-fix](https://imgur.com/ELfCTdc.png)

To test it, install it by:

```
# remove buggy version
rm -rf ~/.roswell/local-projects/koji-kojiro/cl-repl/
# install fixed version
ros install ryukinix/cl-repl/fix/memory-corruption
```

Run using `ros repl` normally.

Closes #44, closes #50