### PR TITLE
Fix an error on exit with C-d, and input y<RET>.

### DIFF
--- a/src/repl.lisp
+++ b/src/repl.lisp
@@ -11,7 +11,8 @@
       ("")
       ("y")
       ("n" (return-from exit-with-prompt (setf *last-input* "nil")))
-      (otherwise (return-from exit-with-prompt (exit-with-prompt)))))
+      (otherwise (return-from exit-with-prompt (exit-with-prompt))))
+    (uiop:quit))
   (throw *debugger-level* nil))
 
 (defvar *output-indicator-function*


### PR DESCRIPTION
Fix to exit successfully.

```
CL-USER> ;; <C-d> here
Do you really want to exit ([y]/n)? y
attempt to THROW to a tag that does not exist: 0
 [Condition of type SIMPLE-CONTROL-ERROR]

Restarts:
 0: [*ABORT] Deduce debugger level.
 1: [*EXIT] Exit CL-REPL.
 2: [*RETRY] Try evaluating again.

Backtrace:
 0: (CL-REPL::EXIT-WITH-PROMPT)
 1: (CL-REPL::READ-INPUT)
 --more--

Usage:
  Ctrl+r: select restart. Ctrl+t: show backtrace.

[1]CL-USER>
```